### PR TITLE
Fix print statements

### DIFF
--- a/colortable.py
+++ b/colortable.py
@@ -78,5 +78,5 @@ if __name__ == '__main__':
     header = ['name', 'male', 'age']
 
     for colorfmt in ['dark', 'green', 'red', 'blue']:
-        print table(row, header, colorfmt=colorfmt)
-        print
+        print(table(row, header, colorfmt=colorfmt))
+        print()


### PR DESCRIPTION
The print statement for the table is not Py3 compatible. This wraps the call in parenthesis to fix that. The following print statement was not printing anything because the function was not actually being called. Fixed that too.